### PR TITLE
Show assignee in violations table and add filter

### DIFF
--- a/src/components/modules/filter_components/Assignees.js
+++ b/src/components/modules/filter_components/Assignees.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export default (props) => {
+  const { setAssignee, assignee, assignees } = props
+
+  const options = [
+    { id: '', label: 'Всички' },
+    ...assignees.map((user) => ({
+      id: user.id,
+      label: `${user.firstName} ${user.lastName}`,
+    })),
+  ]
+
+  const changeHandler = (event) => {
+    setAssignee(event.target.value)
+  }
+
+  return (
+    <select value={assignee} onChange={changeHandler}>
+      {options.map(({ id, label }, index) => (
+        <option key={index} value={id}>
+          {label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/components/modules/violations/ViolationFilter.js
+++ b/src/components/modules/violations/ViolationFilter.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 
 import { AuthContext } from '../../App'
 
+import Assignees from '../filter_components/Assignees'
 import Statuses from '../filter_components/Statuses'
 import TextInput from '../filter_components/TextInput'
 import Published from '../filter_components/Published'
@@ -82,6 +83,9 @@ export default function ViolationFilter(props) {
   const [statuses, setStatuses] = useState([])
   const [status, setStatus] = useState('')
 
+  const [assigneeUsers, setAssigneeUsers] = useState([])
+  const [assignee, setAssignee] = useState('')
+
   let url = ''
 
   let params = {
@@ -93,6 +97,7 @@ export default function ViolationFilter(props) {
     cityRegion: cityRegion,
     status: status,
     published: published,
+    assignee: assignee,
   }
 
   for (const [key, value] of Object.entries(params)) {
@@ -109,6 +114,11 @@ export default function ViolationFilter(props) {
 
     const resStatuses = await authGet('/violations/statuses')
     setStatuses(resStatuses.data)
+
+    const resUsers = await authGet('/users')
+    if (resUsers.data && resUsers.data.items) {
+      setAssigneeUsers(resUsers.data.items)
+    }
 
     //if country is NOT Bulgaria: gets all the cities in the foreign country
     if (country !== '000') {
@@ -144,6 +154,7 @@ export default function ViolationFilter(props) {
     setTown('')
     setSection('')
     setPublished('')
+    setAssignee('')
   }
 
   return (
@@ -166,7 +177,14 @@ export default function ViolationFilter(props) {
               setStatus={setStatus}
             />
           </td>
-          <td></td>
+          <td>
+            Назначен:<br></br>
+            <Assignees
+              assignee={assignee}
+              setAssignee={setAssignee}
+              assignees={assigneeUsers}
+            />
+          </td>
         </tr>
         <tr>
           <td>

--- a/src/components/modules/violations/ViolationList.js
+++ b/src/components/modules/violations/ViolationList.js
@@ -255,7 +255,7 @@ export default (props) => {
           <ViolationTable>
             <thead>
               <tr>
-                {/* <th>Назначен</th> */}
+                <th>Назначен</th>
                 <th>№ на секция</th>
                 <th>Град</th>
                 <th>Автор</th>
@@ -267,7 +267,7 @@ export default (props) => {
             <tbody>
               {loading ? (
                 <tr key="loading">
-                  <td colSpan="6">
+                  <td colSpan="7">
                     <Loading />
                   </td>
                 </tr>
@@ -277,13 +277,13 @@ export default (props) => {
                     key={violation.id}
                     onClick={() => openViolation(violation.id)}
                   >
-                    {/* <td
+                    <td
                       style={
                         violation.assignees.length === 0 ? {} : { padding: 0 }
                       }
                     >
                       {assignees(violation.assignees)}
-                    </td> */}
+                    </td>
                     <td>
                       {!violation.section ? (
                         <i>Не е посочена секция</i>


### PR DESCRIPTION
## Summary
- Uncomment the existing assignee column in the violations listing table (shows initials badge or "Свободен")
- Add an assignee dropdown filter to the violations filter bar
- New `Assignees` filter component fetches users from `/users` endpoint

## Test plan
- [ ] Open violations list — verify the "Назначен" column appears with assignee initials
- [ ] Select an assignee from the filter dropdown and click "Търси" — verify only their violations show
- [ ] Click "Изчисти" — verify the assignee filter resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)